### PR TITLE
Allow moving directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var rimraf = require('rimraf');
 var CachingWriter = require('broccoli-caching-writer');
 var helpers = require('broccoli-kitchen-sink-helpers')
 
@@ -20,7 +21,7 @@ Mover.prototype._copyFile = function (directory, source, destination, leaveOrigi
     path.join(directory, source),
     path.join(directory, destination));
 
-  if (!leaveOriginal) { fs.unlinkSync(path.join(directory, source)); }
+  if (!leaveOriginal) { rimraf.sync(path.join(directory, source)); }
 };
 
 Mover.prototype.updateCache = function (srcDir, destDir) {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   ],
   "dependencies": {
     "broccoli-caching-writer": "~0.1.1",
-    "broccoli-kitchen-sink-helpers": "~0.2.0"
+    "broccoli-kitchen-sink-helpers": "~0.2.0",
+    "rimraf": "~2.2.6"
   },
   "devDependencies": {
     "mocha": "~1.18.2",
-    "rimraf": "~2.2.6",
     "broccoli": "~0.9.0",
     "expect.js": "~0.3.1"
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -51,6 +51,46 @@ describe('broccoli-file-mover', function(){
     });
   })
 
+  it('moves a directory from srcFile to destFile by default', function(){
+    var sourcePath = 'tests/fixtures/sample-ember-style-package';
+    var tree = moveFile(sourcePath, {
+      srcFile: '/lib',
+      destFile: '/other'
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var main = fs.readFileSync(sourcePath + '/lib/main.js');
+      var core = fs.readFileSync(sourcePath + '/lib/core.js');
+
+      expect(fs.readFileSync(dir + '/other/main.js')).to.eql(main);
+      expect(fs.readFileSync(dir + '/other/core.js')).to.eql(core);
+
+      expect(fs.existsSync(dir + '/lib')).to.not.be.ok();
+    });
+  });
+
+  it('copies a directory from srcFile to destFile', function(){
+    var sourcePath = 'tests/fixtures/sample-ember-style-package';
+    var tree = moveFile(sourcePath, {
+      srcFile: '/lib',
+      destFile: '/other',
+      copy: true
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function(dir) {
+      var main = fs.readFileSync(sourcePath + '/lib/main.js');
+      var core = fs.readFileSync(sourcePath + '/lib/core.js');
+
+      expect(fs.readFileSync(dir + '/lib/main.js')).to.eql(main);
+      expect(fs.readFileSync(dir + '/lib/core.js')).to.eql(core);
+
+      expect(fs.readFileSync(dir + '/other/main.js')).to.eql(main);
+      expect(fs.readFileSync(dir + '/other/core.js')).to.eql(core);
+    });
+  });
+
   describe('accepts a hash of objects as the `file` option', function() {
     it('moves each file referenced', function(){
       var sourcePath = 'tests/fixtures/sample-ember-style-package';


### PR DESCRIPTION
Allows for moving directories instead of only individual files. This was actually already supported in the copy case, just needed the unlink to be made recursive for the move scenario.
